### PR TITLE
feat: upgrade simple_auth_flutter to modern Flutter compatibility

### DIFF
--- a/simple_auth_flutter/android/build.gradle
+++ b/simple_auth_flutter/android/build.gradle
@@ -8,7 +8,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.1.3'
+        classpath 'com.android.tools.build:gradle:8.10.1'
     }
 }
 
@@ -22,12 +22,13 @@ rootProject.allprojects {
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 28
+    namespace 'clancey.simpleauth.simpleauthflutter'
+    compileSdkVersion 35
 
     namespace 'clancey.simpleauth.simpleauthflutter'
 
     defaultConfig {
-        minSdkVersion 16
+        minSdkVersion 23
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
     lintOptions {

--- a/simple_auth_flutter/android/src/main/java/clancey/simpleauth/simpleauthflutter/SimpleAuthFlutterPlugin.java
+++ b/simple_auth_flutter/android/src/main/java/clancey/simpleauth/simpleauthflutter/SimpleAuthFlutterPlugin.java
@@ -30,19 +30,8 @@ public class SimpleAuthFlutterPlugin implements FlutterPlugin, ActivityAware,Met
   private MethodChannel methodChannel;
   private EventChannel eventChannel;
 
-  private MethodChannel channel;
   @Override
-  public void onAttachedToEngine(@NonNull FlutterPluginBinding flutterPluginBinding) {
-    channel = new MethodChannel(flutterPluginBinding.getBinaryMessenger(), "simple_auth_flutter/showAuthenticator");
-    final EventChannel eventChannel =
-            new EventChannel(registrar.messenger(), "simple_auth_flutter/urlChanged");
-    eventChannel.setStreamHandler(this);
-    channel.setMethodCallHandler(this);
 
-  }
-
-
-  @Override
   public void onMethodCall(MethodCall call, Result result)   {
     if(call.method.equals("showAuthenticator")){
       try {

--- a/simple_auth_flutter/android/src/main/java/clancey/simpleauth/simpleauthflutter/SimpleAuthFlutterPlugin.java
+++ b/simple_auth_flutter/android/src/main/java/clancey/simpleauth/simpleauthflutter/SimpleAuthFlutterPlugin.java
@@ -129,15 +129,7 @@ public class SimpleAuthFlutterPlugin implements FlutterPlugin, ActivityAware,Met
     _eventSink = null;
   }
 
-  /**
-   * Plugin registration.
-   */
 
-  @SuppressWarnings("deprecation")
-  public static void registerWith(io.flutter.plugin.common.PluginRegistry.Registrar registrar) {
-    final SimpleAuthFlutterPlugin instance = new SimpleAuthFlutterPlugin();
-    instance.onAttachedToEngine(registrar.context(), registrar.messenger());
-  }
 
   @Override
   public void onAttachedToEngine(@NonNull FlutterPluginBinding flutterPluginBinding) {

--- a/simple_auth_flutter/example/android/build.gradle
+++ b/simple_auth_flutter/example/android/build.gradle
@@ -5,7 +5,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.1.2'
+        classpath 'com.android.tools.build:gradle:8.10.1'
     }
 }
 


### PR DESCRIPTION
- Update Android Gradle Plugin from 4.1.3 to 8.10.1
- Update compileSdk from 28 to 35, minSdk from 16 to 23
- Replace deprecated jcenter() with mavenCentral()
- Remove deprecated PluginRegistry.Registrar registerWith method
- Add namespace declaration for AGP 8.x compatibility